### PR TITLE
Couple usability / compatibility tweaks

### DIFF
--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -485,7 +485,7 @@ if [ -z $IP ]; then
         PIDOF_ADB="$(pidof adb)"
         if test -n "$PIDOF_ADB" && ss -lptn src ":$PORT" | grep -q "pid=${PIDOF_ADB}"; then
             if confirm "Your port $PORT seems to be in use by ADB: would you like to clear the previous port before continuing?"; then
-                adb forward --remove tcp:$PORT
+                "$ADB" $ADB_FLAGS forward --remove tcp:$PORT
             else
                 exit 1
             fi

--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -21,10 +21,6 @@
 # - upper-left-diagonal: flip across upper-left/lower-right diagonal
 # - upper-right-diagonal: flip across upper-right/lower-left diagonal
 #
-# However, some of these flip methods do not seem to work. In
-# particular, those which change the picture size, such as clockwise
-# or counterclockwise. *-flip and rotate-180 do work, though.
-#
 # To be able to use audio from your phone as a virtual microphone, open pavucontrol,
 # then open Playback tab and choose 'IP Webcam' for gst-launch-1.0 playback Stream.
 # Then to use audio stream in Audacity, open it and press record button or click on
@@ -460,10 +456,10 @@ pipeline_video() {
       ! queue \
       ! multipartdemux ! "image/jpeg,framerate=$FPS" \
       ! decodebin \
-      $GST_FLIP \
       ! $GST_VIDEO_CONVERTER \
       ! videoscale \
       ! $GST_VIDEO_CAPS \
+      $GST_FLIP \
       $GST_TEE \
       ! v4l2sink device="$DEVICE" sync=$SYNC
 }

--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -178,10 +178,10 @@ FLIP_METHOD=
 # use a usual default, without fps the caps negotiation might fail
 FPS=30/1
 
-# Default dimensions of video, can be overridden on command line.
+# Dimensions of video are infered from the source, can be overridden on command line.
 # Make sure both dimensions are multiples of 16 (see issue #97).
-WIDTH=640
-HEIGHT=480
+WIDTH=
+HEIGHT=
 
 # Force syncing to timestamps. Useful to keep audio and video in sync,
 # but may impact performance in slow connections. If you see errors about
@@ -283,10 +283,9 @@ then
     GST_AUDIO_FORMAT="format=S16LE"
     GST_AUDIO_LAYOUT=",layout=interleaved"
 fi
+DIMENSIONS="${WIDTH:+,width=$WIDTH}${HEIGHT:+,height=$HEIGHT}"
 
-DIMENSIONS="width=$WIDTH,height=$HEIGHT"
-
-GST_VIDEO_CAPS="$GST_VIDEO_MIMETYPE,$GST_VIDEO_FORMAT,$DIMENSIONS"
+GST_VIDEO_CAPS="$GST_VIDEO_MIMETYPE,$GST_VIDEO_FORMAT$DIMENSIONS"
 GST_AUDIO_CAPS="$GST_AUDIO_MIMETYPE,$GST_AUDIO_FORMAT$GST_AUDIO_LAYOUT,$GST_AUDIO_RATE,$GST_AUDIO_CHANNELS"
 PA_AUDIO_CAPS="$GST_AUDIO_FORMAT $GST_AUDIO_RATE $GST_AUDIO_CHANNELS"
 


### PR DESCRIPTION
Hi @agarciadom,
Once I started to poke in the script in #122, I saw it could use some further polishing of things that bit me during getting acquainted. Here's a triplet of changes I locally tested to work and personally believe make the usability of the script a tiny bit better:
- v4l2loopback device detection - the v4l2loopback driver has a native sysfs way of tracking which devices it manages, so one shouldn't need the `v4l2-ctl` utility - which was originally missing for me and I had to install it just for this (and then for debugging, I admit :smile:).
- i saw you had problems with the image flipping, there's a silly fix that does the trick for me
- I also kinda disliked the script's default resolution, which I find too small for today's videoconference standards Also it makes more sense to me for the use to set this in the IPWebcam app (to plan the phone-to-pc network load accordingly). I had no issues with strange dimensions being used as described in #97, so I made the dimensions overrides entirely voluntary and generally inferred from the source.

This would need some further testing on some other distros than my bleeding edge fedora 37 :slightly_smiling_face: , but I hope it's worth it.